### PR TITLE
Ch11

### DIFF
--- a/ch11/nummod-rank-n/Main.hs
+++ b/ch11/nummod-rank-n/Main.hs
@@ -1,7 +1,7 @@
-import NumUtils
+import NumUtils ( NumModifier(..) )
 
 processInts :: NumModifier -> [Int] -> [Int]
-processInts nm xs = map (run nm) xs
+processInts nm = map (run nm)
 
 main :: IO ()
 main = print $ processInts (NumModifier (+1)) [1,2,3]

--- a/ch11/temperature/UnitNameProxies.hs
+++ b/ch11/temperature/UnitNameProxies.hs
@@ -4,8 +4,8 @@
 
 module UnitNameProxies where
 
-import Data.Proxy
-import TempPhantom
+import Data.Proxy ( Proxy(..) )
+import TempPhantom ( C, F, Temp(..) )
 
 class UnitName u where
   unitName :: Proxy u -> String

--- a/ch11/temperature/UnitNameTypeApps.hs
+++ b/ch11/temperature/UnitNameTypeApps.hs
@@ -5,7 +5,7 @@
 
 module UnitNameTypeApps where
 
-import TempPhantom
+import TempPhantom ( C, F, Temp(..) )
 
 class UnitName u where
   unitName :: String

--- a/ch11/temperature/temp-proxies.hs
+++ b/ch11/temperature/temp-proxies.hs
@@ -1,5 +1,5 @@
-import TempPhantom
-import UnitNameProxies
+import TempPhantom ( diff, absoluteZero, paperBurning, Temp )
+import UnitNameProxies ( UnitName(..), unit )
 
 data K
 

--- a/ch11/temperature/temp-type-apps.hs
+++ b/ch11/temperature/temp-type-apps.hs
@@ -1,5 +1,5 @@
-import TempPhantom
-import UnitNameTypeApps
+import TempPhantom ( diff, absoluteZero, paperBurning, Temp )
+import UnitNameTypeApps ( UnitName, unit )
 
 printTemp :: UnitName u => Temp u -> IO ()
 printTemp t = do

--- a/ch11/type-families/Main.hs
+++ b/ch11/type-families/Main.hs
@@ -1,7 +1,7 @@
-import SimplifyWiden
-import Unescape
-import XListable
-import Graphs
+import SimplifyWiden ( Widener(widen), Simplifier(simplify) )
+import Unescape ( uprint )
+import XListable ( testXList )
+import Graphs ( Edge(MkEdge1), neighbors, isLoop, g1 )
 
 testGraphs :: IO ()
 testGraphs = do

--- a/ch11/type-lits/Main.hs
+++ b/ch11/type-lits/Main.hs
@@ -2,12 +2,12 @@
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Pointers
-import SuffixedStrings
+import Pointers ( Pointer, ptrValue, inc, maybePtr, zeroPtr )
+import SuffixedStrings ( SuffixedString, suffixed, asString )
 
 main :: IO ()
 main = do
-    print $ ptrValue $ somePtr -- must be 8
+    print $ ptrValue somePtr -- must be 8
     print $ ptrValue <$> mbptr1
     print $ ptrValue <$> mbptr2
     putStrLn $ asString id1

--- a/ch11/type-lits/Pointers.hs
+++ b/ch11/type-lits/Pointers.hs
@@ -5,8 +5,8 @@
 -- Example: aligned pointers
 module Pointers (Pointer, ptrValue, inc, maybePtr, zeroPtr) where
 
-import GHC.TypeLits
-import Data.Proxy
+import GHC.TypeLits ( KnownNat, Nat, natVal )
+import Data.Proxy ( Proxy(..) )
 
 newtype Pointer (align :: Nat) = Pointer Integer
 

--- a/ch11/type-lits/SuffixedStrings.hs
+++ b/ch11/type-lits/SuffixedStrings.hs
@@ -4,15 +4,15 @@
 
 module SuffixedStrings (SuffixedString, suffixed, asString) where
 
-import GHC.TypeLits
-import Data.Proxy
+import GHC.TypeLits ( KnownSymbol, Symbol, symbolVal )
+import Data.Proxy ( Proxy(..) )
 
 -- Example: suffixed strings
 
 data SuffixedString (suffix :: Symbol) = SS String
 
 suffixed :: String -> SuffixedString suffix
-suffixed s = SS s
+suffixed = SS
 
 asString :: forall suffix. KnownSymbol suffix =>
             SuffixedString suffix -> String

--- a/expr/gadts/Main.hs
+++ b/expr/gadts/Main.hs
@@ -30,4 +30,4 @@ data SomeExpr where
   Some :: Expr a -> SomeExpr
 
 main :: IO ()
-main = print $ myeval $ expr2
+main = print $ myeval expr2

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1248,18 +1248,18 @@ executable temp-type-apps
 --     , containers >=0.5 && <0.7
 --   default-language: Haskell2010
 
--- executable type-lits
---   main-is: Main.hs
---   other-modules:
---       Pointers
---       SuffixedStrings
---   hs-source-dirs:
---       ch11/type-lits
---   other-extensions: DataKinds KindSignatures ScopedTypeVariables
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable type-lits
+  main-is: Main.hs
+  other-modules:
+      Pointers
+      SuffixedStrings
+  hs-source-dirs:
+      ch11/type-lits
+  other-extensions: DataKinds KindSignatures ScopedTypeVariables
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 executable type-operators
   main-is: ch11/type-operators.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -811,18 +811,18 @@ executable maybe
 --     , mtl >=2.0 && <2.3
 --   default-language: Haskell2010
 
--- executable nummod-rank-n
---   main-is: Main.hs
---   other-modules:
---       NumUtils
---       Paths_hid_examples
---   hs-source-dirs:
---       ch11/nummod-rank-n/
---   other-extensions: RankNTypes
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable nummod-rank-n
+  main-is: Main.hs
+  other-modules:
+      NumUtils
+      Paths_hid_examples
+  hs-source-dirs:
+      ch11/nummod-rank-n/
+  other-extensions: RankNTypes
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable opaleye
 --   other-modules:

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1231,22 +1231,22 @@ executable temp-type-apps
 --     , base >=4.12 && <4.15
 --   default-language: Haskell2010
 
--- executable type-families
---   main-is: Main.hs
---   other-modules:
---       Graphs
---       SimplifyWiden
---       Unescape
---       XListable
---       Paths_hid_examples
---   hs-source-dirs:
---       ch11/type-families
---   other-extensions: TypeFamilies FlexibleInstances
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults
---   build-depends:
---       base >=4.12 && <4.15
---     , containers >=0.5 && <0.7
---   default-language: Haskell2010
+executable type-families
+  main-is: Main.hs
+  other-modules:
+      Graphs
+      SimplifyWiden
+      Unescape
+      XListable
+      Paths_hid_examples
+  hs-source-dirs:
+      ch11/type-families
+  other-extensions: TypeFamilies FlexibleInstances
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults
+  build-depends:
+      base
+    , containers
+  default-language: Haskell2010
 
 executable type-lits
   main-is: Main.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -542,15 +542,15 @@ executable evalrpn3
     , transformers
   default-language: Haskell2010
 
--- executable expr-gadt
---   main-is: expr/gadts/Main.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: GADTSyntax GADTs
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults -Wno-missing-signatures
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable expr-gadt
+  main-is: expr/gadts/Main.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: GADTSyntax GADTs
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-type-defaults -Wno-missing-signatures
+  build-depends:
+      base
+  default-language: Haskell2010
 
 executable filecount
   main-is: filecount.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1261,13 +1261,13 @@ executable temp-type-apps
 --       base >=4.12 && <4.15
 --   default-language: Haskell2010
 
--- executable type-operators
---   main-is: ch11/type-operators.hs
---   other-extensions: TypeOperators NoStarIsType
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable type-operators
+  main-is: ch11/type-operators.hs
+  other-extensions: TypeOperators NoStarIsType
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable unboxed
 --   main-is: ch09/unboxed.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1195,18 +1195,18 @@ executable sumlist
 --       base >=4.12 && <4.15
 --   default-language: Haskell2010
 
--- executable temp-proxies
---   main-is: temp-proxies.hs
---   other-modules:
---       TempPhantom
---       UnitNameProxies
---   hs-source-dirs:
---       ch11/temperature
---   other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds InstanceSigs
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable temp-proxies
+  main-is: temp-proxies.hs
+  other-modules:
+      TempPhantom
+      UnitNameProxies
+  hs-source-dirs:
+      ch11/temperature
+  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds InstanceSigs
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable temp-type-apps
 --   main-is: temp-type-apps.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1185,15 +1185,15 @@ executable sumlist
 --     , transformers >=0.5 && <0.6
 --   default-language: Haskell2010
 
--- executable temp-kinds
---   main-is: temp-kinds.hs
---   hs-source-dirs:
---       ch11/temperature
---   other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable temp-kinds
+  main-is: temp-kinds.hs
+  hs-source-dirs:
+      ch11/temperature
+  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
+  build-depends:
+      base
+  default-language: Haskell2010
 
 executable temp-proxies
   main-is: temp-proxies.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -474,15 +474,15 @@ executable du
     , unix-compat
   default-language: Haskell2010
 
--- executable dynvalues-gadt
---   main-is: ch11/dynvalues-gadt.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: GADTs
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable dynvalues-gadt
+  main-is: ch11/dynvalues-gadt.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: GADTs
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable elevator
 --   main-is: UseSafe.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1208,18 +1208,18 @@ executable temp-proxies
       base
   default-language: Haskell2010
 
--- executable temp-type-apps
---   main-is: temp-type-apps.hs
---   other-modules:
---       TempPhantom
---       UnitNameTypeApps
---   hs-source-dirs:
---       ch11/temperature
---   other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable temp-type-apps
+  main-is: temp-type-apps.hs
+  other-modules:
+      TempPhantom
+      UnitNameTypeApps
+  hs-source-dirs:
+      ch11/temperature
+  other-extensions: GeneralizedNewtypeDeriving ScopedTypeVariables PolyKinds AllowAmbiguousTypes TypeApplications
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable tree-async
 --   main-is: ch16/tree-async.hs


### PR DESCRIPTION
## Type system advances

This chapter is devoted to programming at the level of types. We’ll explore a variety of Haskell features that makes it possible. As we’ve discussed earlier in this book, types help us to control software behavior and express our ideas on what the code should and shouldn’t do. Heavily typed code is highly resistant to some sorts of bugs. It also enables aggressive refactoring. If we do something wrong, the Haskell type checker would report that.

We’ll discuss features and techniques available to any Haskell programmer. While presenting them, I limit myself to simple, contrived examples. In particular, we’ll discuss the types and kinds system, data kinds, type families, generalized algebraic data types, and polymorphism. I conclude this chapter with ways to deal with errors while programming at the type level.

 Almost everything discussed in this chapter is not standard Haskell and is implemented in GHC via extensions. By the end of this chapter, you will understand and be able to use all the following GHC extensions:
```haskell
{-# LANGUAGE DataKinds #-}
{-# LANGUAGE PolyKinds #-}
{-# LANGUAGE TypeFamilies #-}
{-# LANGUAGE ScopedTypeVariables #-}
{-# LANGUAGE KindSignatures #-}
{-# LANGUAGE TypeApplications #-}
{-# LANGUAGE TypeOperators #-}
{-# LANGUAGE AllowAmbiguousTypes #-}
{-# LANGUAGE ExplicitForAll #-}
{-# LANGUAGE GADTs #-}
{-# LANGUAGE GADTSyntax #-}
```
The chapter “GHC Language Features” in the GHC User’s Guide (for GHC 8.8) contains 40 sections in total, and about two-thirds of them describe various type-level features. Some of them are old and stable whereas others are novel. Some of them are rather large and deep; others are small additions to the ways we specify types in Haskell.

 In this chapter, I attempt to draw a group portrait of Haskell type-level programming features, leaving thorough individual descriptions to the GHC User’s Guide and the papers behind them.