### PR TITLE
Ch13

### DIFF
--- a/ch13/api/Api2.hs
+++ b/ch13/api/Api2.hs
@@ -4,8 +4,8 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE TypeFamilies #-}
 
-import Data.Kind
-import GHC.TypeLits
+import Data.Kind ( Type )
+import GHC.TypeLits ( Symbol )
 
 import Text.Read (readMaybe)
 
@@ -75,7 +75,7 @@ encode :: Show a => IO a -> IO String
 encode m = show <$> m
 
 route :: Server BookInfoAPI -> Request -> Maybe (IO String)
-route (root :<|> _) [] = pure $ encode $ root
+route (root :<|> _) [] = pure $ encode root
 route (_ :<|> title :<|> year :<|> rating) [op, bid'] = do
   bid <- readMaybe bid'
   case op of

--- a/ch13/api/Api3.hs
+++ b/ch13/api/Api3.hs
@@ -9,9 +9,9 @@
 {-# LANGUAGE InstanceSigs #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 
-import Data.Kind
-import GHC.TypeLits
-import Data.Proxy
+import Data.Kind ( Type )
+import GHC.TypeLits ( KnownSymbol, Symbol, symbolVal )
+import Data.Proxy ( Proxy(..) )
 
 import Control.Applicative ((<|>))
 
@@ -81,7 +81,7 @@ class HasServer layout where
 instance Show a => HasServer (Get a) where
   route :: Proxy (Get a)
         -> HandlerAction a -> Request -> Maybe (IO String)
-  route _ handler [] = Just (encode $ handler)
+  route _ handler [] = Just (encode handler)
   route _ _       _  = Nothing
 
 instance {-# OVERLAPS #-} HasServer (Get String) where

--- a/ch13/api/ApiServant.hs
+++ b/ch13/api/ApiServant.hs
@@ -4,12 +4,12 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-import GHC.Generics
-import Data.Aeson
-import Servant
-import Servant.HTML.Blaze
+import GHC.Generics ( Generic )
+import Data.Aeson ( ToJSON )
+import Servant ( Proxy(..), serve, type (:<|>)(..), Capture, JSON, type (:>), Get, Server, Application )
+import Servant.HTML.Blaze ( HTML )
 import qualified Text.Blaze.Html5 as H
-import Network.Wai.Handler.Warp
+import Network.Wai.Handler.Warp ( run )
 
 data Rating = Bad | Good | Great
   deriving (Show, Generic, ToJSON)

--- a/ch13/doors/SingGen.hs
+++ b/ch13/doors/SingGen.hs
@@ -15,12 +15,12 @@
 #endif
 
 
-import Data.Singletons.TH
+import Data.Singletons.TH ( SingI(..), SingKind(fromSing), singletons )
 
 $(singletons [d|
  data DoorState = Opened | Closed
-  deriving Show
  |])
+deriving instance Show DoorState
 
 data Door (s :: DoorState) where
   MkDoor :: SingI s => Door s

--- a/ch13/doors/SingManual.hs
+++ b/ch13/doors/SingManual.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE ScopedTypeVariables #-}
 {-# LANGUAGE GADTs #-}
-{-# LANGUAGE TypeOperators #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE StandaloneDeriving #-}
 

--- a/ch13/elevator/Elevator/Safe.hs
+++ b/ch13/elevator/Elevator/Safe.hs
@@ -2,15 +2,16 @@
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE KindSignatures #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE ExplicitNamespaces #-}
 
 module Elevator.Safe (module X, call, callSome, SomeFloor(..),
                      SomeElevator(..), mkSomeFloor) where
 
-import Control.Monad.Trans
-import Data.Type.Equality
-import Numeric.Natural
-import Data.Type.Nat
-import Data.Proxy
+import Control.Monad.Trans ( MonadIO(..) )
+import Data.Type.Equality ( type (:~:)(Refl) )
+import Numeric.Natural ( Natural )
+import Data.Type.Nat ( fromNatural, reify, Nat, SNatI )
+import Data.Proxy ( Proxy )
 
 import Elevator.Safe.Floor as X
 import Elevator.Safe.Operations as X

--- a/ch13/elevator/Elevator/Safe/Floor.hs
+++ b/ch13/elevator/Elevator/Safe/Floor.hs
@@ -9,10 +9,10 @@
 
 module Elevator.Safe.Floor where
 
-import Data.Type.Nat
-import Data.Type.Nat.LE
-import Data.Type.Equality
-import Data.Type.Dec
+import Data.Type.Nat ( eqNat, snat, snatToNat, withSNat, Nat(S), SNat(SS), SNatI )
+import Data.Type.Nat.LE ( decideLE, leStepL, withLEProof, LE(..), LEProof )
+import Data.Type.Equality ( type (:~:) )
+import Data.Type.Dec ( Dec(..) )
 
 
 type GoodFloor mx cur = (SNatI mx, SNatI cur, LE cur mx)

--- a/ch13/elevator/Elevator/Safe/Moves.hs
+++ b/ch13/elevator/Elevator/Safe/Moves.hs
@@ -8,13 +8,13 @@
 
 module Elevator.Safe.Moves where
 
-import Data.Type.Nat
-import Data.Type.Nat.LE
-import Data.Type.Dec
-import Data.Type.Equality
-import Data.Void
+import Data.Type.Nat ( discreteNat, snat, Nat(S), SNat(..) )
+import Data.Type.Nat.LE ( decideLE, leSwap, leTrans, withLEProof, LE(..), LEProof(..) )
+import Data.Type.Dec ( Dec(..), Neg )
+import Data.Type.Equality ( type (:~:)(..) )
+import Data.Void ( absurd )
 
-import Elevator.Safe.Floor
+import Elevator.Safe.Floor ( Floor(..), BelowTop )
 
 data Move mx to from where
   StandStill :: Move mx to to

--- a/ch13/elevator/Elevator/Safe/Operations.hs
+++ b/ch13/elevator/Elevator/Safe/Operations.hs
@@ -51,24 +51,24 @@ instance Show (Elevator mx cur door) where
 up :: (BelowTop mx cur, MonadIO m) =>
       Elevator mx cur Closed -> m (Elevator mx (S cur) Closed)
 up (MkElevator fl) = do
-  liftIO $ LL.up
+  liftIO LL.up
   pure (MkElevator $ next fl)
 
 down :: MonadIO m => Elevator mx (S cur) Closed -> m (Elevator mx cur Closed)
 down (MkElevator fl) = do
-  liftIO $ LL.down
+  liftIO LL.down
   pure $ MkElevator $ prev fl
 
 open :: MonadIO m =>
         Floor mx cur -> Elevator mx cur Closed -> m (Elevator mx cur Opened)
 open _ (MkElevator fl) = do
-  liftIO $ LL.open
+  liftIO LL.open
   pure (MkElevator fl)
 
 close :: MonadIO m =>
          Floor mx cur -> Elevator mx cur Opened -> m (Elevator mx cur Closed)
 close _ (MkElevator fl) = do
-  liftIO $ LL.close
+  liftIO LL.close
   pure (MkElevator fl)
 
 ensureClosed :: forall mx cur door m. MonadIO m =>

--- a/ch13/elevator/Elevator/Safe/Operations.hs
+++ b/ch13/elevator/Elevator/Safe/Operations.hs
@@ -21,17 +21,18 @@
 
 module Elevator.Safe.Operations where
 
-import Data.Type.Nat
-import Data.Singletons.TH
-import Control.Monad.Trans
+import Data.Type.Nat ( Nat(S) )
+import Data.Singletons.TH ( Sing, SingI(..), SingKind(fromSing), singletons )
+import Control.Monad.Trans ( MonadIO(..) )
 
 import qualified Elevator.LowLevel as LL
-import Elevator.Safe.Floor
+import Elevator.Safe.Floor ( Floor, BelowTop, next, prev )
 
 $(singletons [d|
  data Door = Opened | Closed
-  deriving (Eq, Show)
   |])
+deriving instance Eq Door
+deriving instance Show Door
 
 data Elevator (mx :: Nat) (cur :: Nat) (door :: Door) where
   MkElevator :: SingI door => Floor mx cur -> Elevator mx cur door

--- a/ch13/elevator/Elevator/Unsafe.hs
+++ b/ch13/elevator/Elevator/Unsafe.hs
@@ -2,7 +2,7 @@ module Elevator.Unsafe where
 
 import qualified Elevator.LowLevel as LL
 
-import Control.Monad.Trans
+import Control.Monad.Trans ( MonadIO(..) )
 
 data DoorState = Opened | Closed
   deriving (Eq, Show)
@@ -43,7 +43,7 @@ aboveGround fl = fl > minBound
 down :: MonadIO m => Elevator -> m Elevator
 down el@(Elevator fl@(Floor n) Closed)
   | aboveGround fl = do
-      liftIO $ LL.down
+      liftIO LL.down
       pure $ el {current = Floor (n - 1)}
   | otherwise = error "Elevator is on the ground floor"
 down (Elevator _ Opened) = error "Door must be closed before move"
@@ -51,7 +51,7 @@ down (Elevator _ Opened) = error "Door must be closed before move"
 up :: MonadIO m => Elevator -> m Elevator
 up el@(Elevator fl@(Floor n) Closed)
   | belowTop fl = do
-      liftIO $ LL.up
+      liftIO LL.up
       pure $ el {current = Floor (n + 1)}
   | otherwise = error "Elevator on the top floor"
 up (Elevator _ Opened) = error "Door must be closed before move"
@@ -61,7 +61,7 @@ open fl el
   | sameFloor fl el =
       if isClosed el
       then do
-        liftIO $ LL.open
+        liftIO LL.open
         pure $ el {door = Opened}
       else error "Door is already opened"
   | otherwise = error "Can't operate the door with an elevator elsewhere"
@@ -71,7 +71,7 @@ close fl el
   | sameFloor fl el =
       if isOpened el
       then do
-        liftIO $ LL.close
+        liftIO LL.close
         pure $ el {door = Closed}
       else error "Door is already closed"
   | otherwise = error "Can't operate the door with an elevator elsewhere"
@@ -94,4 +94,4 @@ call fl el = do
   liftIO $ putStrLn $ "Call to: " <> show fl
   if sameFloor fl el
     then (if isOpened el then pure el else open fl el)
-    else (moveTo fl el >>= open fl)
+    else moveTo fl el >>= open fl

--- a/ch13/elevator/UseSafe.hs
+++ b/ch13/elevator/UseSafe.hs
@@ -1,10 +1,18 @@
 {-# LANGUAGE DataKinds #-}
 
 import Elevator.Safe
+    ( Door(Closed),
+      Floor(..),
+      Elevator(..),
+      SomeElevator(MkSomeElevator),
+      SomeFloor,
+      call,
+      mkSomeFloor,
+      callSome )
 
-import Data.Type.Nat
-import Control.Monad
-import System.Environment
+import Data.Type.Nat ( Nat0, Nat2, Nat3, Nat5 )
+import Control.Monad ( foldM_ )
+import System.Environment ( getArgs )
 
 type MX = Nat5
 

--- a/ch13/elevator/UseUnsafe.hs
+++ b/ch13/elevator/UseUnsafe.hs
@@ -1,7 +1,7 @@
-import Control.Monad
-import System.Environment
+import Control.Monad ( foldM_ )
+import System.Environment ( getArgs )
 
-import Elevator.Unsafe
+import Elevator.Unsafe ( Elevator(Elevator), Floor(Floor), DoorState(Closed), call )
 
 gfElevator :: Elevator
 gfElevator = Elevator (Floor 0) Closed

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -383,16 +383,17 @@ executable door
       base
   default-language: Haskell2010
 
--- executable door-gen
---   main-is: ch13/doors/SingGen.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
---   build-depends:
---       base >=4.12 && <4.15
---     , singletons >=2.5 && <2.8
---   default-language: Haskell2010
+executable door-gen
+  main-is: ch13/doors/SingGen.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
+  build-depends:
+      base
+    , singletons
+    , singletons-th
+  default-language: Haskell2010
 
 -- executable dots
 --   main-is: ch16/dots.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -373,15 +373,15 @@ executable dicegame
 --     , exceptions >=0.10 && <0.11
 --   default-language: Haskell2010
 
--- executable door
---   main-is: ch13/doors/SingManual.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable door
+  main-is: ch13/doors/SingManual.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: DataKinds GADTs TypeOperators KindSignatures StandaloneDeriving
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable door-gen
 --   main-is: ch13/doors/SingGen.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -224,15 +224,15 @@ executable api-stage2
       base
   default-language: Haskell2010
 
--- executable api-stage3
---   main-is: ch13/api/Api3.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies FlexibleInstances InstanceSigs ScopedTypeVariables
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable api-stage3
+  main-is: ch13/api/Api3.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies FlexibleInstances InstanceSigs ScopedTypeVariables
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable async-exc
 --   main-is: ch16/async-exc.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -196,14 +196,14 @@ library shunting-yard
 --     , warp >=3.2 && <3.4
 --   default-language: Haskell2010
 
--- executable api-stage0
---   main-is: ch13/api/Api0.hs
---   other-modules:
---       Paths_hid_examples
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable api-stage0
+  main-is: ch13/api/Api0.hs
+  other-modules:
+      Paths_hid_examples
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable api-stage1
 --   main-is: ch13/api/Api1.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -485,24 +485,25 @@ executable dynvalues-gadt
       base
   default-language: Haskell2010
 
--- executable elevator
---   main-is: UseSafe.hs
---   other-modules:
---       Elevator.LowLevel
---       Elevator.Safe
---       Elevator.Safe.Floor
---       Elevator.Safe.Operations
---       Elevator.Safe.Moves
---   hs-source-dirs:
---       ch13/elevator/
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
---   build-depends:
---       base >=4.12 && <4.15
---     , dec >=0.0.3 && <0.1
---     , fin >=0.1 && <0.3
---     , mtl >=2.0 && <2.3
---     , singletons >=2.5 && <2.8
---   default-language: Haskell2010
+executable elevator
+  main-is: UseSafe.hs
+  other-modules:
+      Elevator.LowLevel
+      Elevator.Safe
+      Elevator.Safe.Floor
+      Elevator.Safe.Operations
+      Elevator.Safe.Moves
+  hs-source-dirs:
+      ch13/elevator/
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans -Wno-unticked-promoted-constructors
+  build-depends:
+      base
+    , dec
+    , fin
+    , mtl
+    , singletons
+    , singletons-th
+  default-language: Haskell2010
 
 executable evalrpn1
   main-is: evalrpn1.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -205,14 +205,14 @@ executable api-stage0
       base
   default-language: Haskell2010
 
--- executable api-stage1
---   main-is: ch13/api/Api1.hs
---   other-modules:
---       Paths_hid_examples
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable api-stage1
+  main-is: ch13/api/Api1.hs
+  other-modules:
+      Paths_hid_examples
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable api-stage2
 --   main-is: ch13/api/Api2.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -1279,18 +1279,18 @@ executable type-operators
 --       base >=4.12 && <4.15
 --   default-language: Haskell2010
 
--- executable unsafe-elevator
---   main-is: UseUnsafe.hs
---   other-modules:
---       Elevator.LowLevel
---       Elevator.Unsafe
---   hs-source-dirs:
---       ch13/elevator/
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---     , mtl >=2.0 && <2.3
---   default-language: Haskell2010
+executable unsafe-elevator
+  main-is: UseUnsafe.hs
+  other-modules:
+      Elevator.LowLevel
+      Elevator.Unsafe
+  hs-source-dirs:
+      ch13/elevator/
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+    , mtl
+  default-language: Haskell2010
 
 executable via
   main-is: via.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -214,15 +214,15 @@ executable api-stage1
       base
   default-language: Haskell2010
 
--- executable api-stage2
---   main-is: ch13/api/Api2.hs
---   other-modules:
---       Paths_hid_examples
---   other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       base >=4.12 && <4.15
---   default-language: Haskell2010
+executable api-stage2
+  main-is: ch13/api/Api2.hs
+  other-modules:
+      Paths_hid_examples
+  other-extensions: KindSignatures TypeOperators PolyKinds DataKinds TypeFamilies
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      base
+  default-language: Haskell2010
 
 -- executable api-stage3
 --   main-is: ch13/api/Api3.hs

--- a/hid-examples.cabal
+++ b/hid-examples.cabal
@@ -182,19 +182,19 @@ library shunting-yard
     , text-show
   default-language: Haskell2010
 
--- executable api-servant
---   main-is: ch13/api/ApiServant.hs
---   other-modules:
---       Paths_hid_examples
---   ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
---   build-depends:
---       aeson >=1.2 && <1.6
---     , base >=4.12 && <4.15
---     , blaze-html >=0.9 && <0.10
---     , servant-blaze >=0.7 && <0.10
---     , servant-server >=0.14 && <0.19
---     , warp >=3.2 && <3.4
---   default-language: Haskell2010
+executable api-servant
+  main-is: ch13/api/ApiServant.hs
+  other-modules:
+      Paths_hid_examples
+  ghc-options: -Wall -Werror -Wcompat -Widentities -Wincomplete-uni-patterns -Wincomplete-record-updates -Wno-unused-top-binds -Wno-orphans
+  build-depends:
+      aeson
+    , base
+    , blaze-html
+    , servant-blaze
+    , servant-server
+    , warp
+  default-language: Haskell2010
 
 executable api-stage0
   main-is: ch13/api/Api0.hs


### PR DESCRIPTION
## More about types
We’ve discussed a lot of powerful Haskell features in the previous chapters. To keep the presentation simple, I tried to talk about them in isolation. Their powers become much stronger, however, when we use them in combination. We can achieve a huge boost in the expressiveness of our types together with the provable safety of our programs if we apply types, type classes, type families, GADTs, and Template Haskell at once. In this chapter, I demonstrate how we can do that in two extended examples.

 In the first section we’ll explore the usage of type families and type classes to describe and implement RESTful web services. We’ll do that in the vein of the Servant library, the most-used Haskell library for implementing web services.

 In the second section, we’ll implement a safe type-controlled interface for elevators. Software correctness becomes of primary importance when we work with hardware devices. We’ll use GADTs as the main building blocks to do fully featured type-level programming in Haskell, although we need almost everything else, too.
Along the way we’ll implement _singletons_, special values that can be operated on both the term level and the type level. Singletons will bring us to the idea of dependent type programming, when types depend on values. GHC does not yet support fully dependent types at the time of writing, though we can already use many dependently typed techniques.